### PR TITLE
Replaced username with email.

### DIFF
--- a/a2_starter_code/a2_group11/website/forms.py
+++ b/a2_starter_code/a2_group11/website/forms.py
@@ -43,7 +43,7 @@ class EventForm(FlaskForm):
 
 # creates the login information
 class LoginForm(FlaskForm):
-    user_name=StringField("User Name", validators=[InputRequired('Enter user name')])
+    email = StringField("Email Address", validators=[Email("Please enter a valid email")])
     password=PasswordField("Password", validators=[InputRequired('Enter user password')])
     submit = SubmitField("Login")
 

--- a/a2_starter_code/a2_group11/website/models.py
+++ b/a2_starter_code/a2_group11/website/models.py
@@ -23,7 +23,8 @@ class User(db.Model, UserMixin):
     __tablename__ = "users"
     # Placeholder User data attributes subject to change
     user_id = db.Column(db.Integer, primary_key=True)
-    username = db.Column(db.String(50), unique=True, nullable=False)
+    first_name = db.Column(db.String(50), unique=True, nullable=False)
+    surname = db.Column(db.String(50), unique=True, nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
     phone = db.Column(db.String(10), nullable=True)
     address = db.Column(db.String(50), nullable=True)


### PR DESCRIPTION
Assignment specifications do not specify the requirement of a username, therefore email will be used for login. Username field for user has been split into first name and surname.